### PR TITLE
[feat] evals attempted by adding back the default `say_hello` tool

### DIFF
--- a/foundaudio/foundaudio/__init__.py
+++ b/foundaudio/foundaudio/__init__.py
@@ -1,3 +1,4 @@
 from foundaudio.tools.get_audio_list import get_audio_list
+from foundaudio.tools.hello import say_hello
 
-__all__ = ["get_audio_list"]
+__all__ = ["say_hello", "get_audio_list"]

--- a/foundaudio/foundaudio/tools/__init__.py
+++ b/foundaudio/foundaudio/tools/__init__.py
@@ -1,3 +1,4 @@
 from foundaudio.tools.get_audio_list import get_audio_list
+from foundaudio.tools.hello import say_hello
 
-__all__ = ["get_audio_list"]
+__all__ = ["say_hello", "get_audio_list"]

--- a/foundaudio/foundaudio/tools/hello.py
+++ b/foundaudio/foundaudio/tools/hello.py
@@ -1,0 +1,10 @@
+from typing import Annotated
+
+from arcade_tdk import tool
+
+
+@tool
+def say_hello(name: Annotated[str, "The name of the person to greet"]) -> str:
+    """Say a greeting!"""
+
+    return "Hello, " + name + "!"


### PR DESCRIPTION
# Summary

Unfortunately was unable to get `evals` to work. Documented the issue [here](https://github.com/rsmets/arcade-foundaudio-toolkit/issues/9).

Added back the default `say_hello` tool to sanity check and still having issues. 